### PR TITLE
Fix: add __fl columns to coalesce macro

### DIFF
--- a/macros/coalesce_fields.sql
+++ b/macros/coalesce_fields.sql
@@ -18,7 +18,7 @@
 
             {%- set col_split = col.column.split('__') -%}
             {%- if col_split|length > 1 and col_split[-1]|lower in (
-                'bl','st','it','bigint','string','double','boolean'
+                'fl','bl','st','it','bigint','string','double','boolean'
             ) -%}
             
                 {%- set status = 'guilty' -%}


### PR DESCRIPTION
This PR updates the coalesce macro to include `__fl` columns (fixes #8)