### PR TITLE
Handle columns with double underscores in the name

### DIFF
--- a/integration_tests/data/data_coalesce_fields.csv
+++ b/integration_tests/data/data_coalesce_fields.csv
@@ -1,4 +1,4 @@
-id,numeral,numeral__st,numeral__bl,version__string,version__double,properties__numeral__st,properties__numeral__bl,__red_herring
-1,1,,,pi,,1,not
-2,,one,,,3.14,one,this
-3,,,TRUE,,,,,one
+id,numeral,numeral__st,numeral__bl,version__string,version__double,properties__numeral,properties__numeral__st,properties__numeral__bl,__red_herring
+1,1,,,pi,,1,,,not
+2,,one,,,3.14,,one,,this
+3,,,TRUE,,,,,TRUE,one

--- a/integration_tests/data/data_coalesce_fields.csv
+++ b/integration_tests/data/data_coalesce_fields.csv
@@ -1,4 +1,4 @@
-id,numeral,numeral__st,numeral__bl,version__string,version__double,__red_herring
-1,1,,,pi,,not
-2,,one,,,3.14,this
-3,,,TRUE,,,one
+id,numeral,numeral__st,numeral__bl,version__string,version__double,properties__numeral__st,properties__numeral__bl,__red_herring
+1,1,,,pi,,1,not
+2,,one,,,3.14,one,this
+3,,,TRUE,,,,,one

--- a/integration_tests/data/data_coalesce_fields_expected.csv
+++ b/integration_tests/data/data_coalesce_fields_expected.csv
@@ -1,4 +1,4 @@
-id,numeral,version,__red_herring
-1,"1","pi","not"
-2,"one","3.14","this"
-3,"true",,"one"
+id,numeral,version,properties__numeral,__red_herring
+1,"1","pi","1","not"
+2,"one","3.14","one","this"
+3,"true",,"true","one"

--- a/macros/coalesce_fields.sql
+++ b/macros/coalesce_fields.sql
@@ -9,10 +9,10 @@
     {%- set finals = [] -%}
 
     {%- for col in cols -%}
-    
+
         {%- set status = 'innocent' -%}
 
-        {#- Stitch-synced duplicate columns are named `field__datatype` or 
+        {#- Stitch-synced duplicate columns are named `field__datatype` or
         `field__dt`, where dt = abbreviated datatype -#}
         {%- if '__' in col.column -%}
 
@@ -20,12 +20,12 @@
             {%- if col_split|length > 1 and col_split[-1]|lower in (
                 'fl','bl','st','it','bigint','string','double','boolean'
             ) -%}
-            
-                {%- set status = 'guilty' -%}
-                
-                {%- set name_without_datatype = col_split[:-1][0] -%}
 
-                {%- set column = 
+                {%- set status = 'guilty' -%}
+
+                {%- set name_without_datatype = col_split[:-1]|join('__') -%}
+
+                {%- set column =
                     {
                         'name' : adapter.quote(col.column | string),
                         'datatype' : col.data_type,
@@ -36,32 +36,32 @@
                 {#- keep lists of columns to fix -#}
                 {%- do cols_to_coalesce.append(column) -%}
                 {%- do colnames_tofix.append(name_without_datatype) -%}
-            
+
             {%- endif -%}
 
         {%- endif %}
-        
+
         {%- if status == 'innocent' -%}
             {%- do clean_cols.append(col) -%}
         {%- endif -%}
     {%- endfor -%}
 
     {%- for col in clean_cols %}
-        {#- check clean column name against coalesce output and 
+        {#- check clean column name against coalesce output and
         add all unduplicated, unmatched columns to final list -#}
         {%- if col.column not in colnames_tofix %}
             {%- set clean_col = adapter.quote(col.column) -%}
             {%- do finals.append(clean_col) -%}
         {% else -%}
         {#- if clean column has datatyped cousin, add to list for fixing -#}
-            {%- set column = 
+            {%- set column =
                 {
                     'name' : adapter.quote(col.column | string),
                     'datatype' : col.data_type,
                     'name_without_datatype' : adapter.quote(col.column | string)
                 }
             -%}
-            
+
             {%- do cols_to_coalesce.append(column) -%}
         {% endif -%}
     {% endfor %}
@@ -85,8 +85,8 @@
         {%- endset -%}
         {%- do finals.append(column_exp) -%}
     {%- endfor %}
-    
-    
+
+
 select
 
     {% for final in finals %}


### PR DESCRIPTION
For example 'properties__number_of_sources'.

Previously anything prefixed by 'properties__' was coalesced to 'properties'.

For example this was being generated against our events using segment -> stitch -> Redshift:

```sql
WITH final AS (
  
    
    
select

    coalesce(
                cast("properties__meta__content__count__string" as 
  varchar
),
                cast("properties__meta__frequency__at__string" as 
  varchar
),
                cast("properties__meta__frequency__between__from__string" as 
  varchar
),
                cast("properties__meta__frequency__between__to__string" as 
  varchar
),
                cast("properties__created__string" as 
  varchar
),
                cast("properties__meta__frequency__between__from__bigint" as 
  varchar
),
                cast("properties__meta__frequency__at__bigint" as 
  varchar
),
                cast("properties__meta__frequency__between__to__bigint" as 
  varchar
),
                case
                    when "properties__created__boolean" = true then cast('true' as 
  varchar
)
                    when "properties__created__boolean" = false then cast('false' as 
  varchar
)
                    else null end
                ,
                cast("properties__item__journalistic_quality__double" as 
  varchar
),
                cast("properties__item__journalistic_quality__bigint" as 
  varchar
),
                cast("properties__item__original_id__string" as 
  varchar
),
                cast("properties__sentiment__compound__bigint" as 
  varchar
),
                cast("properties__sentiment__pos__bigint" as 
  varchar
),
                cast("properties__entity__sentiment__neu__bigint" as 
  varchar
),
                cast("properties__entity__sentiment__pos__bigint" as 
  varchar
),
                cast("properties__entity__sentiment__neg__bigint" as 
  varchar
),
                cast("properties__sentiment__neu__bigint" as 
  varchar
),
                cast("properties__entity__sentiment__compound__bigint" as 
  varchar
),
                cast("properties__sentiment__neg__bigint" as 
  varchar
),
                cast("properties__entity__sentiment__compound__double" as 
  varchar
),
                cast("properties__sentiment__neu__double" as 
  varchar
),
                cast("properties__entity__sentiment__pos__double" as 
  varchar
),
                cast("properties__entity__sentiment__neu__double" as 
  varchar
),
                cast("properties__sentiment__compound__double" as 
  varchar
),
                cast("properties__sentiment__pos__double" as 
  varchar
),
                cast("properties__sentiment__neg__double" as 
  varchar
),
                cast("properties__entity__sentiment__neg__double" as 
  varchar
),
                cast("properties__item__original_id__bigint" as 
  varchar
),
                cast("properties__number_of_sources__string" as 
  varchar
),
                cast("properties__number_of_sources__bigint" as 
  varchar
),
                cast("properties__meta__content__count__bigint" as 
  varchar
)) as "properties"

from "analytics"."migrated_app"."track"


)

SELECT * FROM final
```

After this change:

```sql
    coalesce(
                cast("properties__created__string" as 
  varchar
),
                case
                    when "properties__created__boolean" = true then cast('true' as 
  varchar
)
                    when "properties__created__boolean" = false then cast('false' as 
  varchar
)
                    else null end
                ) as "properties__created",
    coalesce(
                cast("properties__entity__sentiment__compound__bigint" as 
  varchar
),
                cast("properties__entity__sentiment__compound__double" as 
  varchar
)) as "properties__entity__sentiment__compound",
    coalesce(
                cast("properties__entity__sentiment__neg__bigint" as 
  varchar
),
                cast("properties__entity__sentiment__neg__double" as 
  varchar
)) as "properties__entity__sentiment__neg",
    coalesce(
                cast("properties__entity__sentiment__neu__bigint" as 
  varchar
),
                cast("properties__entity__sentiment__neu__double" as 
  varchar
)) as "properties__entity__sentiment__neu",
    coalesce(
                cast("properties__entity__sentiment__pos__bigint" as 
  varchar
),
                cast("properties__entity__sentiment__pos__double" as 
  varchar
)) as "properties__entity__sentiment__pos",
    coalesce(
                cast("properties__item__journalistic_quality__double" as 
  varchar
),
                cast("properties__item__journalistic_quality__bigint" as 
  varchar
)) as "properties__item__journalistic_quality",
    coalesce(
                cast("properties__item__original_id__string" as 
  varchar
),
                cast("properties__item__original_id__bigint" as 
  varchar
)) as "properties__item__original_id",
    coalesce(
                cast("properties__meta__content__count__string" as 
  varchar
),
                cast("properties__meta__content__count__bigint" as 
  varchar
)) as "properties__meta__content__count",
    coalesce(
                cast("properties__meta__frequency__at__string" as 
  varchar
),
                cast("properties__meta__frequency__at__bigint" as 
  varchar
)) as "properties__meta__frequency__at",
    coalesce(
                cast("properties__meta__frequency__between__from__string" as 
  varchar
),
                cast("properties__meta__frequency__between__from__bigint" as 
  varchar
)) as "properties__meta__frequency__between__from",
    coalesce(
                cast("properties__meta__frequency__between__to__string" as 
  varchar
),
                cast("properties__meta__frequency__between__to__bigint" as 
  varchar
)) as "properties__meta__frequency__between__to",
    coalesce(
                cast("properties__number_of_sources__string" as 
  varchar
),
                cast("properties__number_of_sources__bigint" as 
  varchar
)) as "properties__number_of_sources",
    coalesce(
                cast("properties__sentiment__compound__bigint" as 
  varchar
),
                cast("properties__sentiment__compound__double" as 
  varchar
)) as "properties__sentiment__compound",
    coalesce(
                cast("properties__sentiment__neg__bigint" as 
  varchar
),
                cast("properties__sentiment__neg__double" as 
  varchar
)) as "properties__sentiment__neg",
    coalesce(
                cast("properties__sentiment__neu__bigint" as 
  varchar
),
                cast("properties__sentiment__neu__double" as 
  varchar
)) as "properties__sentiment__neu",
    coalesce(
                cast("properties__sentiment__pos__bigint" as 
  varchar
),
                cast("properties__sentiment__pos__double" as 
  varchar
)) as "properties__sentiment__pos"

from "analytics"."migrated_app"."track"

```