### PR TITLE
handle __de column suffix (double)

### DIFF
--- a/macros/coalesce_fields.sql
+++ b/macros/coalesce_fields.sql
@@ -18,7 +18,7 @@
 
             {%- set col_split = col.column.split('__') -%}
             {%- if col_split|length > 1 and col_split[-1]|lower in (
-                'fl','bl','st','it','bigint','string','double','boolean'
+                'de','fl','bl','st','it','bigint','string','double','boolean'
             ) -%}
 
                 {%- set status = 'guilty' -%}


### PR DESCRIPTION
This PR adds handling for `__de` column suffixes, which are doubles (Snowflake type was `NUMBER(38,6)`).