### PR TITLE
v0.2.0: dbt v0.17.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/python:3.6.2-stretch
+      - image: circleci/python:3.6.3-stretch
       - image: circleci/postgres:9.6.5-alpine-ram
 
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
           command: |
             python3 -m venv venv
             . venv/bin/activate
-            pip install dbt==0.13.0rc1  # CHANGE THIS AFTER RELEASE!
+            pip install dbt
             mkdir -p ~/.dbt
             cp integration_tests/ci/sample.profiles.yml ~/.dbt/profiles.yml
       

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,9 +1,10 @@
-name: 'stitch_utils'
-version: '0.1.0'
+name: stitch_utils
+version: 0.2.0
+config-version: 2
 
 target-path: "target"
 clean-targets: ["target", "dbt_modules"]
 macro-paths: ["macros"]
 log-path: "logs"
 
-require-dbt-version: ">=0.13.0"
+require-dbt-version: ">=0.17.0"

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,6 +1,7 @@
 
-name: 'stitch_utils_integration_tests'
-version: '1.0'
+name: stitch_utils_integration_tests
+version: 0.2.0
+config-version: 2
 
 profile: 'integration_tests'
 

--- a/integration_tests/packages.yml
+++ b/integration_tests/packages.yml
@@ -1,4 +1,2 @@
 packages:
-  - package: fishtown-analytics/dbt_utils
-    version: '>=0.1.22'
   - local: ../

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - package: fishtown-analytics/dbt_utils
-    version: '>=0.1.19'
+    version: ">=0.1.19"


### PR DESCRIPTION
* `dbt_project.yml`: `config-version 2`
* Use python 3.6.3 in CircleCI
* Cosmetic: clean up version numbers, remove `dbt_utils` requirement from integration tests (redundant with package)