### PR TITLE
Bumps dbt_utils compatibility up to 0.10.0

### DIFF
--- a/macros/coalesce_fields.sql
+++ b/macros/coalesce_fields.sql
@@ -75,11 +75,11 @@
                 {#- handle booleans with especial care -#}
                 {%- if column.datatype in ('boolean', 'bo') %}
                 case
-                    when {{column.name}} = true then cast('true' as {{dbt_utils.type_string()}})
-                    when {{column.name}} = false then cast('false' as {{dbt_utils.type_string()}})
+                    when {{column.name}} = true then cast('true' as {{type_string()}})
+                    when {{column.name}} = false then cast('false' as {{type_string()}})
                     else null end
                 {% else %}
-                cast({{column.name}} as {{dbt_utils.type_string()}}){%- endif -%}{{- "," if not loop.last -}}
+                cast({{column.name}} as {{type_string()}}){%- endif -%}{{- "," if not loop.last -}}
             {% endfor -%}
             ) as {{ group.grouper }}
         {%- endset -%}

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - package: dbt-labs/dbt_utils
-    version: [">=0.8.0", "<0.9.0"]
+    version: [">=0.8.0", "<0.10.0"]

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - package: dbt-labs/dbt_utils
-    version: [">=0.8.0", "<0.10.0"]
+    version: [">=1.0.0"]


### PR DESCRIPTION

## Description & motivation
Allows the the latest release of dbt_utils to be co-installed. Also removes cross-db dbt_util reference (`{{dbt_utils.type_string()}}`) as it's now available in dbt-core.

## Checklist
- [X] I have verified that these changes work locally
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
