### PR TITLE
Update coalesce_fields macro to include inst datatype

### DIFF
--- a/macros/coalesce_fields.sql
+++ b/macros/coalesce_fields.sql
@@ -18,7 +18,7 @@
 
             {%- set col_split = col.column.split('__') -%}
             {%- if col_split|length > 1 and col_split[-1]|lower in (
-                'de','fl','bl','st','it','bigint','string','double','decimal','boolean','bo','ti'
+                'de','fl','bl','st','it','bigint','string','double','decimal','boolean','bo','ti','inst'
             ) -%}
 
                 {%- set status = 'guilty' -%}


### PR DESCRIPTION
## Description & motivation
<!---
Describe your changes, and why you're making them.
-->

We had to update the macro locally to include a strange datatype called 'inst' that was set by Stitch. This is a simple fix and would help us to use the real macro again.

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
